### PR TITLE
Added docs and recipe samples for copying models to OCI object storage.

### DIFF
--- a/docs/model_storage/README.md
+++ b/docs/model_storage/README.md
@@ -8,6 +8,14 @@ OCI AI Blueprints will automatically create an ephemeral volume, mount it to the
 
 ### How To
 
+**Step 1 [OPTIONAL]**:
+
+If serving large models from huggingface, it is recommended to first download them to object storage because they are loaded much more quickly from object storage than via python applications which build in the ability to pull them. 
+
+To download a model from huggingface to object storage, check out [this doc](../common_workflows/working_with_large_models/README.md#download-the-model-to-object-storage-optional-but-recommended).
+
+**Step 2:**
+
 You can host your model via object storage by:
 
 1. Creating a PAR for the bucket that contains your model (`par` in the example below)
@@ -17,21 +25,14 @@ You can host your model via object storage by:
 
 Include the `input_object_storage` JSON object in your deployment payload (`/deployment` POST API):
 
-```
+```json
 "input_object_storage": [
-
 	{
-
 		"par": "https://objectstorage.us-ashburn-1.oraclecloud.com/p/IFknABDAjiiF5LATogUbRCcVQ9KL6aFUC1j-P5NSeUcaB2lntXLaR935rxa-E-u1/n/iduyx1qnmway/b/corrino_hf_oss_models/o/",
-
 		"mount_location": "/models",
-
 		"volume_size_in_gbs": 500,
-
 		"include": ["NousResearch/Meta-Llama-3.1-8B-Instruct"]
-
 	}
-
 ],
 ```
 
@@ -45,6 +46,6 @@ Notes:
 - `include` field inside the `input_object_storage` object inside your payload (shown above) is used to specify which folder inside the bucket to download to the ephemeral volume (that the container has access to via the mount_location directory
 - The entire bucket will be dumped into the ephermal volume / container mount directory if include is not provided to specify the folder inside the folder to download
 
-## Option 2: File Storage Service (FSS)
+## Option 2: File Storage Service (FSS) - Full doc coming soon!
 
 [FSS Details](../fss/README.md)

--- a/docs/sample_blueprints/download_closed_hf_model_to_object_storage.json
+++ b/docs/sample_blueprints/download_closed_hf_model_to_object_storage.json
@@ -1,0 +1,29 @@
+{
+    "recipe_id": "example",
+    "recipe_mode": "job",
+    "deployment_name": "model_to_object",
+    "recipe_image_uri": "iad.ocir.io/iduyx1qnmway/corrino-devops-repository:hf_downloader_v1",
+    "recipe_container_command_args": [
+      "meta-llama/Llama-3.2-90B-Vision-Instruct",
+      "--local-dir",
+      "/models",
+      "--max-workers",
+      "4",
+      "--token",
+      "<hf_token>"
+    ],
+    "recipe_container_port": "5678",
+    "recipe_node_shape": "VM.Standard.E4.Flex",
+    "recipe_node_pool_size": 1,
+    "recipe_flex_shape_ocpu_count": 4,
+    "recipe_flex_shape_memory_size_in_gbs": 64,
+    "recipe_node_boot_volume_size_in_gbs": 500,
+    "recipe_ephemeral_storage_size": 450,
+    "output_object_storage": [
+      {
+        "bucket_name": "llama3290Bvisioninstruct",
+        "mount_location": "/models",
+        "volume_size_in_gbs": 450
+      }
+    ]
+  }

--- a/docs/sample_blueprints/download_open_hf_model_to_object_storage.json
+++ b/docs/sample_blueprints/download_open_hf_model_to_object_storage.json
@@ -1,0 +1,27 @@
+{
+    "recipe_id": "example",
+    "recipe_mode": "job",
+    "deployment_name": "model_to_object",
+    "recipe_image_uri": "iad.ocir.io/iduyx1qnmway/corrino-devops-repository:hf_downloader_v1",
+    "recipe_container_command_args": [
+      "NousResearch/Meta-Llama-3.1-405B-FP8",
+      "--local-dir",
+      "/models",
+      "--max-workers",
+      "16"
+    ],
+    "recipe_container_port": "5678",
+    "recipe_node_shape": "VM.Standard.E4.Flex",
+    "recipe_node_pool_size": 1,
+    "recipe_flex_shape_ocpu_count": 16,
+    "recipe_flex_shape_memory_size_in_gbs": 256,
+    "recipe_node_boot_volume_size_in_gbs": 1000,
+    "recipe_ephemeral_storage_size": 900,
+    "output_object_storage": [
+      {
+        "bucket_name": "nousllama31405bfp8",
+        "mount_location": "/models",
+        "volume_size_in_gbs": 800
+      }
+  ]
+}


### PR DESCRIPTION
Sample blueprints and documentation for copying model to object storage and working with large models.