### PR TITLE
add A2 cpu inference

### DIFF
--- a/docs/sample_blueprints/model_serving/cpu-inference/cpu-inference-A2-bm.json
+++ b/docs/sample_blueprints/model_serving/cpu-inference/cpu-inference-A2-bm.json
@@ -4,11 +4,32 @@
   "deployment_name": "Cpu Inference A2",
   "recipe_image_uri": "ghcr.io/amperecomputingai/ollama-ampere:1.0.0-ol9",
   "recipe_node_shape": "VM.Standard.A2.Flex",
+  "recipe_flex_shape_ocpu_count": 8,
+  "recipe_flex_shape_memory_size_in_gbs": 64,
+  "input_object_storage": [
+    {
+      "par": "https://objectstorage.us-ashburn-1.oraclecloud.com/p/PhxpLO7eu4bDXCB_wshp9jJXsrwxFTAJTEDY6it6tmDdEqIJf-CcZMugp3jfHnb5/n/axusxi89ppdg/b/blueprints-models/o/",
+      "mount_location": "/models",
+      "volume_size_in_gbs": 20
+    }
+  ],
+  "recipe_container_env": [
+ {
+      "key": "OLLAMA_MODELS",
+      "value": "/models"
+    },
+    {
+      "key": "MODEL_NAME",
+      "value": "llama3.1:8b-instruct-q8_0"
+    },
+    {
+      "key": "PROMPT",
+      "value": "What is the capital of Spain?"
+    }
+  ],
   "recipe_replica_count": 1,
   "recipe_container_port": "11434",
   "recipe_node_pool_size": 1,
-  "recipe_flex_shape_ocpu_count": 8,
-  "recipe_ephemeral_storage_size": 100,
   "recipe_node_boot_volume_size_in_gbs": 200,
-  "recipe_flex_shape_memory_size_in_gbs": 64
+  "recipe_ephemeral_storage_size": 100
 }


### PR DESCRIPTION
Hi, 

A proposal of A2 blueprint. The blueprint is similar to this blueprint: https://github.com/oracle-quickstart/oci-ai-blueprints/blob/main/docs/sample_blueprints/model_serving/cpu-inference/cpu-inference-mistral-vm.json

and aimed at reaching similar performance for mistral:7b-instruct-q8_0 and llama3.1:8b-instruct-q8_0 models.

from our internal benchmarks we got such numbers for A2:

mistral:7b-instruct-q8_0
b=1, t=8, tg_throughput=6.27, pp_throughput=446.95, ttft=0.15

llama3.1:8b-instruct-q8_0
b=1, t=8, tg_throughput=5.63, pp_throughput=419.10, ttft=0.20

and such numbers for E4:

mistral:7b-instruct-q8_0
b=1, t=4, tg_throughput=6.91, pp_throughput=470.62, ttft=0.15

llama3.1:8b-instruct-q8_0
b=1, t=4, tg_throughput=6.54, pp_throughput=427.20, ttft=0.17

The main difference in the blueprint is 8 cores for A2 vs 4 cores for E4.
